### PR TITLE
two bug fixes for gestures

### DIFF
--- a/Smartpad-macOS/Smartpad-macOS/Logic/GestureRecognition/SinglePanGesture.swift
+++ b/Smartpad-macOS/Smartpad-macOS/Logic/GestureRecognition/SinglePanGesture.swift
@@ -44,7 +44,8 @@ class SinglePanGesture : Gesture {
         // TODO: A bit janky on a secondary screen, but works fine on primary screen
         let newPos = CGPoint(x: initialPos!.x + CGFloat(payload.xTranslation * TrackpadSetting.getTrackingSpeed()),
                              y: NSScreen.main!.frame.height - initialPos!.y + CGFloat(payload.yTranslation * TrackpadSetting.getTrackingSpeed()))
-        CGDisplayMoveCursorToPoint(CGMainDisplayID(), newPos)
+
+        moveMouse(position: newPos)
 
         // Reset the initialPos to nil when ending a pan
         if (packet.touchType == GestureType.SinglePanEnded) {
@@ -54,5 +55,15 @@ class SinglePanGesture : Gesture {
 
     static func handlesGesture(gestureType: GestureType) -> Bool {
         return types.contains(gestureType)
+    }
+
+    /**
+     * @brief Move the mouse.
+     */
+    static private func moveMouse(position: CGPoint) {
+        let mouseEvent = CGEvent(mouseEventSource: CGEventSource(stateID: .hidSystemState),
+                                 mouseType: CGEventType.mouseMoved,
+                                 mouseCursorPosition: position, mouseButton: .left)
+        mouseEvent?.post(tap: .cghidEventTap)
     }
 }

--- a/Smartpad-macOS/Smartpad-macOS/Logic/GestureRecognition/SingleTapGesture.swift
+++ b/Smartpad-macOS/Smartpad-macOS/Logic/GestureRecognition/SingleTapGesture.swift
@@ -32,6 +32,8 @@ class SingleTapGesture : Gesture {
             leftMouseDownEvent?.post(tap: .cghidEventTap)
 
             let leftMouseUpEvent = CGEvent(mouseEventSource: source, mouseType: .leftMouseUp, mouseCursorPosition: mouseLocation, mouseButton: .left)
+            // don't unclick too fast! Wait a bit
+            usleep(2000)
             leftMouseUpEvent?.post(tap: .cghidEventTap)
         }
     }

--- a/Smartpad-macOS/Smartpad-macOS/Logic/GestureRecognition/SingleTapGesture.swift
+++ b/Smartpad-macOS/Smartpad-macOS/Logic/GestureRecognition/SingleTapGesture.swift
@@ -32,8 +32,6 @@ class SingleTapGesture : Gesture {
             leftMouseDownEvent?.post(tap: .cghidEventTap)
 
             let leftMouseUpEvent = CGEvent(mouseEventSource: source, mouseType: .leftMouseUp, mouseCursorPosition: mouseLocation, mouseButton: .left)
-            // don't unclick too fast! Wait a bit
-            usleep(2000)
             leftMouseUpEvent?.post(tap: .cghidEventTap)
         }
     }

--- a/Smartpad-macOS/Smartpad-macOS/Logic/GestureRecognition/ZoomGesture.swift
+++ b/Smartpad-macOS/Smartpad-macOS/Logic/GestureRecognition/ZoomGesture.swift
@@ -84,6 +84,12 @@ class ZoomGesture : Gesture {
         plusDown?.post(tap: .cghidEventTap)
         // Release CMD+
         plusUp?.post(tap: .cghidEventTap)
+        
+        // clean up
+        // don't forget to unpress command!
+        let commandUp = CGEvent.init(keyboardEventSource: CGEventSource(stateID: .hidSystemState),
+                                    virtualKey: CGKeyCode(kVK_Command), keyDown: false)
+        commandUp?.post(tap: .cghidEventTap)
     }
 
     /**
@@ -103,5 +109,13 @@ class ZoomGesture : Gesture {
         minusDown?.post(tap: .cghidEventTap)
         // Release CMD-
         minusUp?.post(tap: .cghidEventTap)
+        
+        // clean up
+        // don't forget to unpress command!
+        let commandUp = CGEvent.init(keyboardEventSource: CGEventSource(stateID: .hidSystemState),
+                                    virtualKey: CGKeyCode(kVK_Command), keyDown: false)
+        commandUp?.post(tap: .cghidEventTap)
+
     }
+    
 }


### PR DESCRIPTION
I found a couple of pretty severe bugs that needed fixing:
Bug 1 Reproduction steps:
1. Run the apps
2. Pair
3. Open a file (e.g. where's Waldo)
4. Use pinch zoom
Unexpected Behaviours:
1. Can't switch over to a different app with click
2. Can't open Preview's toolbar
3. Can't open apps from dock
Reason for Bug 1: In the zoom gesture, command key was being pressed down but not pressed
Implemented fix for Bug 1: I unpressed the command key

Bug 2 Reproduction steps:
1. Run the apps
2. Pair
3. Right click on a file (e.g. where's Waldo)
4. Single click on "open with ..."
5. Try to fast click on the first option
Unexpected behaviours:
1. It will simply dismiss the right click menu
2. It won't open the file using the selected app

Reason for Bug 2: For the single tap gesture. We where clicking and unclicking the left click too fast, hence it wouldn't detect it properly.
Implemented fix for Bug 2: I added a 2 ms delay between click and unclick for single tap.

Please Review this PR before our meeting. The app works fine now. Cheers and fingers crossed!